### PR TITLE
Use HTTPS site URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 
 title:            Functional programming debugs you
 locale:           en_US
-url:              
+url:              https://nikita-volkov.github.io/
 
 
 # Jekyll configuration


### PR DESCRIPTION
This will hopefully fix the insecure content warnings that you run into if you go to <https://nikita-volkov.github.io>.